### PR TITLE
feat: allow GdsContent background in nightmode to be lightGray if needed

### DIFF
--- a/components/src/main/java/uk/gov/android/ui/components/m3/content/Content.kt
+++ b/components/src/main/java/uk/gov/android/ui/components/m3/content/Content.kt
@@ -16,17 +16,27 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import uk.gov.android.ui.components.content.GdsContentText
 import uk.gov.android.ui.components.m3.Heading
-import uk.gov.android.ui.theme.GdsTheme
+import uk.gov.android.ui.theme.inverseOnSurface
+import uk.gov.android.ui.theme.m3.GdsTheme
+import uk.gov.android.ui.theme.mc_theme_dark_inverseOnSurface
 
 @Composable
 fun GdsContent(
     contentParameters: ContentParameters,
-    colors: ColorScheme = MaterialTheme.colorScheme
+    colors: ColorScheme = MaterialTheme.colorScheme,
+    changeBackgroundDefault: Boolean = false
 ) {
     Column(
         modifier = Modifier
             .background(
-                color = colors.background
+                color = if (changeBackgroundDefault) {
+                    inverseOnSurface(
+                        darkMode = mc_theme_dark_inverseOnSurface,
+                        lightMode = colors.background
+                    )
+                } else {
+                    colors.background
+                }
             )
             .then(
                 contentParameters.modifier

--- a/theme/src/main/java/uk/gov/android/ui/theme/Color.kt
+++ b/theme/src/main/java/uk/gov/android/ui/theme/Color.kt
@@ -1,5 +1,7 @@
 package uk.gov.android.ui.theme
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 
 val disabled_button = Color(0xFFB1B4B6)
@@ -34,3 +36,15 @@ val md_theme_dark_onPrimary = Color(0xFFFFFFFF)
 val md_theme_dark_onSecondary = Color(0xFFFFFFFF)
 val md_theme_dark_onSurface = Color(0xFFFFFFFF)
 val mc_theme_dark_inverseOnSurface = Color(0xFF262626)
+
+/**
+ * Allows to change the [Theme] colors if requirements are different from the standard.
+ */
+@Composable
+fun inverseOnSurface(darkMode: Color, lightMode: Color): Color {
+    return if (isSystemInDarkTheme()) {
+        darkMode
+    } else {
+        lightMode
+    }
+}


### PR DESCRIPTION
- add a new parameter (boolean) to allow to confirm if background needs to be dark gray
- add function for custom inverseBackground colors