### PR TITLE
[PSREDEV-1911] Upgrading upload-artifact due to v3 deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
       interval: "daily"
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/config/actions/**"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/config/actions/upload-dokka/action.yml
+++ b/config/actions/upload-dokka/action.yml
@@ -12,9 +12,8 @@ runs:
 
     - name: Upload Dokka Documentation
       id: uploadDokka
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # pin@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
       with:
         name: documentation
         retention-days: 14
-        path: |
-          documentation.zip
+        path: documentation.zip


### PR DESCRIPTION
Thic change updates the dependabot configuration to find the actions hosted in the non-default location. This is also a test of the dependabot config to see if it will view the actions in /config/actions