### PR TITLE
Fix: DCMAW-10164 Add toolchain auto-provisioning

### DIFF
--- a/buildLogic/plugins/build.gradle.kts
+++ b/buildLogic/plugins/build.gradle.kts
@@ -7,7 +7,7 @@ val sonarqubeVersion by rootProject.extra("4.3.0.3225")
 
 dependencies {
     listOf(
-        "com.android.tools.build:gradle:8.0.0",
+        "com.android.tools.build:gradle:8.7.0",
         "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.0.21-1.0.27",
         "org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:$kotlinVersion",
         "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",

--- a/components/build.gradle.kts
+++ b/components/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
     listOf(
         "com.android.library",
         "kotlin-parcelize",
-        "org.jetbrains.kotlin.android",
         "org.jlleitschuh.gradle.ktlint",
         "io.gitlab.arturbosch.detekt",
         "jacoco",
@@ -75,6 +74,7 @@ android {
         xmlReport = true
     }
 
+    @Suppress("UnstableApiUsage")
     testOptions {
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
         animationsDisabled = true
@@ -138,7 +138,7 @@ publishing {
             groupId = "uk.gov.android"
             version = rootProject.extra["packageVersion"] as String
 
-            artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+            artifact("${layout.buildDirectory}/outputs/aar/${project.name}-release.aar")
         }
     }
     repositories {

--- a/components/src/androidTest/java/uk/gov/android/ui/components/BulletListTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/BulletListTest.kt
@@ -5,16 +5,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.components.content.GdsContentText
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class BulletListTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/GdsIconComposableTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/GdsIconComposableTest.kt
@@ -10,18 +10,15 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.components.images.icon.GdsIconPreview
 import uk.gov.android.ui.components.images.icon.GdsIconProvider
 import uk.gov.android.ui.components.images.icon.IconParameters
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class GdsIconComposableTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val resources = context.resources

--- a/components/src/androidTest/java/uk/gov/android/ui/components/HeadingsTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/HeadingsTest.kt
@@ -5,12 +5,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import uk.gov.android.ui.theme.GdsTheme
 import uk.gov.android.ui.theme.lineHeightH1
@@ -24,7 +22,6 @@ import uk.gov.android.ui.theme.textSizeH4
 import uk.gov.android.ui.utils.extensions.assertFontSize
 import uk.gov.android.ui.utils.extensions.assertLineHeight
 
-@RunWith(AndroidJUnit4::class)
 class HeadingsTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/HelpTextTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/HelpTextTest.kt
@@ -5,15 +5,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class HelpTextTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/content/BulletListTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/content/BulletListTest.kt
@@ -5,15 +5,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class BulletListTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/content/ContentTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/content/ContentTest.kt
@@ -7,15 +7,12 @@ import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class ContentTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/content/LinkTextTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/content/LinkTextTest.kt
@@ -5,15 +5,12 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class LinkTextTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/information/InformationTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/information/InformationTest.kt
@@ -5,17 +5,15 @@ import android.content.res.Resources
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.components.content.verifyComposable
 import uk.gov.android.ui.components.verifyComposable
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class) // Parameterized runner seems to crash
+// Parameterized runner seems to crash
 class InformationTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val resources = context.resources

--- a/components/src/androidTest/java/uk/gov/android/ui/components/inputs/date/DatePickerTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/inputs/date/DatePickerTest.kt
@@ -3,15 +3,12 @@ package uk.gov.android.ui.components.inputs.date
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class DatePickerTest {
     private val expectedParameterSize = 1
     private val parameterList = DatePickerProvider().values.toList()

--- a/components/src/androidTest/java/uk/gov/android/ui/components/inputs/number/NumberInputTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/inputs/number/NumberInputTest.kt
@@ -3,15 +3,12 @@ package uk.gov.android.ui.components.inputs.number
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class NumberInputTest {
     private val expectedParameterSize = 1
     private val parameterList = NumberInputProvider().values.toList()

--- a/components/src/androidTest/java/uk/gov/android/ui/components/inputs/radio/RadioOptionsTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/inputs/radio/RadioOptionsTest.kt
@@ -3,15 +3,12 @@ package uk.gov.android.ui.components.inputs.radio
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class RadioOptionsTest {
     private val expectedParameterSize = 1
     private val parameterList = RadioSelectionProvider().values.toList()

--- a/components/src/androidTest/java/uk/gov/android/ui/components/m3/BulletListTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/m3/BulletListTest.kt
@@ -5,16 +5,13 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.components.content.GdsContentText
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class)
 class BulletListTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/components/src/androidTest/java/uk/gov/android/ui/components/m3/GdsInformationBannerTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/m3/GdsInformationBannerTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
-import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import uk.gov.android.ui.components.R

--- a/components/src/androidTest/java/uk/gov/android/ui/components/m3/HeadingsM3Test.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/m3/HeadingsM3Test.kt
@@ -5,12 +5,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.theme.lineHeightH1
 import uk.gov.android.ui.theme.lineHeightH2
 import uk.gov.android.ui.theme.lineHeightH3
@@ -23,7 +21,6 @@ import uk.gov.android.ui.theme.textSizeH4
 import uk.gov.android.ui.utils.extensions.assertFontSize
 import uk.gov.android.ui.utils.extensions.assertLineHeight
 
-@RunWith(AndroidJUnit4::class)
 class HeadingsM3Test {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val resources = context.resources

--- a/components/src/androidTest/java/uk/gov/android/ui/components/m3/information/InformationTest.kt
+++ b/components/src/androidTest/java/uk/gov/android/ui/components/m3/information/InformationTest.kt
@@ -5,17 +5,15 @@ import android.content.res.Resources
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import uk.gov.android.ui.components.m3.content.verifyComposable
 import uk.gov.android.ui.components.verifyComposable
 import uk.gov.android.ui.theme.m3.GdsTheme
 
-@RunWith(AndroidJUnit4::class) // Parameterized runner seems to crash
+// Parameterized runner seems to crash
 class InformationTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val resources = context.resources

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 05 14:44:27 BST 2023
+#Wed Oct 30 20:10:54 GMT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/pages/build.gradle.kts
+++ b/pages/build.gradle.kts
@@ -7,7 +7,6 @@ buildscript {
 plugins {
     listOf(
         "com.android.library",
-        "org.jetbrains.kotlin.android",
         "org.jlleitschuh.gradle.ktlint",
         "io.gitlab.arturbosch.detekt",
         "jacoco",
@@ -143,7 +142,7 @@ publishing {
             groupId = "uk.gov.android"
             version = rootProject.extra["packageVersion"] as String
 
-            artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+            artifact("${layout.buildDirectory}/outputs/aar/${project.name}-release.aar")
         }
     }
     repositories {

--- a/pages/src/androidTest/java/uk/gov/android/ui/pages/LoadingScreenTest.kt
+++ b/pages/src/androidTest/java/uk/gov/android/ui/pages/LoadingScreenTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import uk.gov.android.ui.theme.m3.GdsTheme

--- a/pages/src/androidTest/java/uk/gov/android/ui/pages/errors/ErrorPageTest.kt
+++ b/pages/src/androidTest/java/uk/gov/android/ui/pages/errors/ErrorPageTest.kt
@@ -4,18 +4,16 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class) // Parameterized tests seems to crash
+// Parameterized tests seems to crash
 class ErrorPageTest {
     @get:Rule
     val composeTestRule = createComposeRule()

--- a/pages/src/androidTest/java/uk/gov/android/ui/pages/m3/LandingPageTest.kt
+++ b/pages/src/androidTest/java/uk/gov/android/ui/pages/m3/LandingPageTest.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
-import junit.framework.TestCase.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 import uk.gov.android.ui.pages.LandingPage

--- a/pages/src/androidTest/java/uk/gov/android/ui/pages/m3/errors/ErrorPageTest.kt
+++ b/pages/src/androidTest/java/uk/gov/android/ui/pages/m3/errors/ErrorPageTest.kt
@@ -4,19 +4,17 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import uk.gov.android.ui.pages.errors.ErrorPageTags
 import uk.gov.android.ui.theme.GdsTheme
 
-@RunWith(AndroidJUnit4::class) // Parameterized tests seems to crash
+// Parameterized tests seems to crash
 class ErrorPageTest {
     @get:Rule
     val composeTestRule = createComposeRule()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,7 @@ pluginManagement {
 
 plugins {
     id("de.fayard.refreshVersions")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.8.0")
 }
 
 refreshVersions {

--- a/theme/build.gradle.kts
+++ b/theme/build.gradle.kts
@@ -7,7 +7,6 @@ buildscript {
 plugins {
     listOf(
         "com.android.library",
-        "org.jetbrains.kotlin.android",
         "org.jlleitschuh.gradle.ktlint",
         "io.gitlab.arturbosch.detekt",
         "jacoco",
@@ -129,7 +128,7 @@ publishing {
             groupId = "uk.gov.android"
             version = rootProject.extra["packageVersion"] as String
 
-            artifact("$buildDir/outputs/aar/${project.name}-release.aar")
+            artifact("${layout.buildDirectory}/outputs/aar/${project.name}-release.aar")
         }
     }
     repositories {

--- a/theme/src/androidTest/java/uk/gov/android/ui/theme/StubInstrumentationTest.kt
+++ b/theme/src/androidTest/java/uk/gov/android/ui/theme/StubInstrumentationTest.kt
@@ -1,14 +1,12 @@
 package uk.gov.android.ui.theme
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
 
 /**
  * Remove this class once there are other instrumentation tests in this source set.
  */
-@RunWith(AndroidJUnit4::class)
+
 class StubInstrumentationTest {
 
     @Test


### PR DESCRIPTION
# DCMAW-10164: Add toolchain auto-provisioning

- [Ticket DCMAW-10164](https://govukverify.atlassian.net/browse/DCMAW-10164)

## Description of changes:

- Update gradle from 8.0 to 8.9
- Add toolchain auto-provisioning
- Remove "org.jetbrains.kotlin.android" plugin from sub-modules as it is already on classpath

## Evidence of the change

- Project now builds

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- ~[ ] Complete automated Testing:~
  * ~[ ] Unit Tests.~
  * ~[ ] Integration Tests.~
  * ~[ ] Instrumentation / Emulator Tests.~
- ~[ ] Review [Accessibility considerations].~
- [ ] Handle PR comments.

### Before merging the pull request

- ~[ ] [Sonar cloud report] passes inspections for your PR.~
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-onelogin-app
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing