### PR TITLE
fix: DCMAW-9639 Label Medium

### DIFF
--- a/theme/src/main/java/uk/gov/android/ui/theme/m3/Typography.kt
+++ b/theme/src/main/java/uk/gov/android/ui/theme/m3/Typography.kt
@@ -113,6 +113,24 @@ val Typography = Typography(
         fontSize = buttonTextSize,
         lineHeight = buttonLineHeight,
     ),
+    labelMedium = TextStyle(
+        fontFamily = FontFamily(
+            Font(
+                resId = R.font.gds_transport_light,
+                weight = FontWeight.Light,
+            ),
+            Font(
+                resId = R.font.gds_transport_light,
+                weight = FontWeight.Normal,
+            ),
+            Font(
+                resId = R.font.gds_transport_bold,
+                weight = FontWeight.Bold,
+            ),
+        ),
+        fontSize = buttonTextSize,
+        lineHeight = buttonLineHeight,
+    ),
 )
 
 @Preview


### PR DESCRIPTION
# _DCMAW-9639: Fix Label Medium_

- Reinstates Typography LabelMedium as it was

Context: In updating Typography so that Buttons can automatically pick up the correct style (LabelLarge) I failed to check if LabelMedium was in use. LabelMedium is used in Wallet

## Evidence of the change

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing