### PR TITLE
build: bump android-gradle from 8.7.3 to 8.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity = "1.9.3" # https://developer.android.com/jetpack/androidx/releases/activity
-android-gradle = "8.7.3" # https://developer.android.com/studio/releases/gradle-plugin
+android-gradle = "8.8.0" # https://developer.android.com/studio/releases/gradle-plugin
 androidx-test-ext-junit = "1.2.1" # https://developer.android.com/jetpack/androidx/releases/test
 androidx-test-orchestrator = "1.5.1" # https://developer.android.com/jetpack/androidx/releases/test
 appcompat = "1.7.0" # https://developer.android.com/jetpack/androidx/releases/appcompat

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 07 10:55:48 GMT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps `android-gradle` from 8.7.3 to 8.8.0.
Updates `com.android.tools.build:gradle` from 8.7.3 to 8.8.0
Updates `com.android.application` from 8.7.3 to 8.8.0
Updates `com.android.library` from 8.7.3 to 8.8.0