### PR TITLE
fix: Ignore lint issues

### DIFF
--- a/config/android/lint.xml
+++ b/config/android/lint.xml
@@ -13,5 +13,7 @@
 
     <issue id="UsingMaterialAndMaterial3Libraries" severity="ignore" />
     <issue id="GradleDependency" severity="ignore" />
+    <issue id="AndroidGradlePluginVersion" severity="ignore" />
+    <issue id="NewerVersionAvailable" severity="ignore" />
 </lint>
 


### PR DESCRIPTION
fix: Ignore lint issues

Update lint.xml to ignore AndroidGradlePluginVersion, and NewerVersionAvailable