### PR TITLE
build: Add compose lints to componentsv2

### DIFF
--- a/componentsv2/build.gradle.kts
+++ b/componentsv2/build.gradle.kts
@@ -88,6 +88,7 @@ dependencies {
     testImplementation(libs.hilt.android.testing)
     testImplementation(libs.junit)
     testImplementation(libs.mockito.kotlin)
+    lintChecks(libs.com.slack.compose.lint.checks)
 }
 
 mavenPublishingConfig {
@@ -101,5 +102,11 @@ mavenPublishingConfig {
             components module with a more standardised approach.
             """.trimIndent(),
         )
+    }
+}
+
+android {
+    lint {
+        baseline = file("lint-baseline.xml")
     }
 }

--- a/componentsv2/lint-baseline.xml
+++ b/componentsv2/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 8.8.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.8.0)" variant="all" version="8.8.0">
+
+</issues>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-test-orchestrator = "1.5.1" # https://developer.android.com/jetpack/and
 appcompat = "1.7.0" # https://developer.android.com/jetpack/androidx/releases/appcompat
 archcore-testing = "2.2.0"
 compose = "2025.01.00"
+compose-lint-checks = "1.4.2"
 constraintlayout-compose = "1.1.0"
 core-ktx = "1.13.1"
 dagger = "2.55" # https://github.com/google/dagger/releases
@@ -41,6 +42,7 @@ androidx-test-orchestrator = { module = "androidx.test:orchestrator", version.re
 
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 arch-core = { group = "androidx.arch.core", name = "core-testing", version.ref = "archcore-testing" }
+com-slack-compose-lint-checks = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "compose-lint-checks" }
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 detekt-gradle = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt-gradle" }
 hilt-android-testing = { group = "com.google.dagger", name = "hilt-android-testing", version.ref = "dagger" }


### PR DESCRIPTION
Add Slack's compose-lints lint rules to componentsv2.

> These checks are to ensure that your composables don’t fall into common pitfalls that may be easy to miss in code reviews.

[compose-lints]: https://slackhq.github.io/compose-lints/

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
