### PR TITLE
ci: Allow pull request workflow to run for any base branch

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,8 +1,6 @@
 name: On Pull Request
 on:
   pull_request:
-    branches:
-      - main
     types:
       - opened
       - reopened


### PR DESCRIPTION
## Problem

Github Actions workflows do not run for stacked PRs where the base branch is an unmerged branch and not `main`.

## Solution

Allow the PR workflow to run for any base branch.