### PR TITLE
fix: layout issues with full screen dialog and gdscard

### DIFF
--- a/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/GdsCard.kt
+++ b/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/GdsCard.kt
@@ -71,49 +71,44 @@ fun GdsCard(
             contentDescription = contentDescription,
             showDismissIcon = showDismissIcon,
         )
-        Column(
-            modifier = Modifier
-                .weight(1f, false),
-        ) {
-            Row {
-                Column(
-                    modifier = Modifier
-                        .weight(ROW_DISTRIBUTION, false)
-                        .padding(horizontal = smallPadding),
-                ) {
-                    caption?.let {
-                        Text(
-                            text = caption,
-                            style = Typography.bodySmall,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = xsmallPadding),
-                        )
-                    }
+        Row {
+            Column(
+                modifier = Modifier
+                    .weight(ROW_DISTRIBUTION, false)
+                    .padding(horizontal = smallPadding),
+            ) {
+                caption?.let {
                     Text(
-                        text = title,
-                        style = Typography.headlineMedium,
-                        modifier = Modifier.customTilePadding(body != null),
+                        text = caption,
+                        style = Typography.bodySmall,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = xsmallPadding),
                     )
-                    body?.let {
-                        Text(
-                            text = body,
-                            style = Typography.bodyLarge,
-                            modifier = Modifier.padding(vertical = xsmallPadding),
-                        )
-                    }
                 }
-                if (image == null && showDismissIcon) {
-                    DismissIcon()
+                Text(
+                    text = title,
+                    style = Typography.headlineMedium,
+                    modifier = Modifier.customTilePadding(body != null),
+                )
+                body?.let {
+                    Text(
+                        text = body,
+                        style = Typography.bodyLarge,
+                        modifier = Modifier.padding(vertical = xsmallPadding),
+                    )
                 }
             }
-            Buttons(
-                text = buttonText,
-                displayPrimary = displayPrimary,
-                showSecondaryIcon = showSecondaryIcon,
-                onClick = onClick,
-            )
+            if (image == null && showDismissIcon) {
+                DismissIcon()
+            }
         }
+        Buttons(
+            text = buttonText,
+            displayPrimary = displayPrimary,
+            showSecondaryIcon = showSecondaryIcon,
+            onClick = onClick,
+        )
     }
 }
 
@@ -229,7 +224,8 @@ internal data class GdsCardPreviewParameters(
     val showSecondaryIcon: Boolean = false,
 )
 
-internal class GdsCardPreviewParametersProvider : PreviewParameterProvider<GdsCardPreviewParameters> {
+internal class GdsCardPreviewParametersProvider :
+    PreviewParameterProvider<GdsCardPreviewParameters> {
     override val values: Sequence<GdsCardPreviewParameters> = sequenceOf(
         GdsCardPreviewParameters(
             image = R.drawable.ic_tile_image,

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.android.ui.patterns.dialog
 
 import android.content.Context
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -46,6 +47,25 @@ class FullScreenDialogTest {
                 title = titleText,
             ) {
                 Text(contentText)
+            }
+        }
+        composeTestRule.onNode(closeButton).assertIsDisplayed()
+        composeTestRule.onNode(title).assertIsDisplayed()
+        composeTestRule.onNode(content).assertIsDisplayed()
+    }
+
+    @Test
+    fun verifyUIScrollableContent() {
+        composeTestRule.setContent {
+            FullScreenDialog(
+                onDismissRequest = { },
+                title = titleText,
+            ) {
+                LazyColumn {
+                    item {
+                        Text(contentText)
+                    }
+                }
             }
         }
         composeTestRule.onNode(closeButton).assertIsDisplayed()

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
@@ -18,6 +18,7 @@ import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import uk.gov.android.ui.componentsv2.GdsCard
 import uk.gov.android.ui.componentsv2.R
 
 class FullScreenDialogTest {
@@ -71,6 +72,23 @@ class FullScreenDialogTest {
         composeTestRule.onNode(closeButton).assertIsDisplayed()
         composeTestRule.onNode(title).assertIsDisplayed()
         composeTestRule.onNode(content).assertIsDisplayed()
+    }
+
+    @Test
+    fun verifyUIGdsCardDisplayed() {
+        composeTestRule.setContent {
+            FullScreenDialog(
+                onDismissRequest = { },
+            ) {
+                GdsCard(
+                    titleText,
+                    {},
+                )
+            }
+        }
+
+        composeTestRule.onNode(closeButton).assertIsDisplayed()
+        composeTestRule.onNode(title).assertIsDisplayed()
     }
 
     @Test

--- a/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialog.kt
+++ b/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialog.kt
@@ -2,13 +2,9 @@ package uk.gov.android.ui.patterns.dialog
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Scaffold
@@ -110,8 +106,7 @@ fun FullScreenDialog(
                 topBar = { topAppBar() },
             ) { innerPadding ->
                 Column(
-                    modifier = modifier.height(IntrinsicSize.Max)
-                        .verticalScroll(rememberScrollState())
+                    modifier = modifier
                         .padding(innerPadding)
                         .fillMaxWidth(),
                     verticalArrangement = Arrangement.SpaceBetween,
@@ -129,7 +124,8 @@ internal data class FullScreenDialogPreviewParameters(
     val content: @Composable () -> Unit = { },
 )
 
-internal class FullScreenDialogPreviewProvider : PreviewParameterProvider<FullScreenDialogPreviewParameters> {
+internal class FullScreenDialogPreviewProvider :
+    PreviewParameterProvider<FullScreenDialogPreviewParameters> {
     override val values: Sequence<FullScreenDialogPreviewParameters> =
         sequenceOf(
             FullScreenDialogPreviewParameters(),

--- a/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialog.kt
+++ b/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialog.kt
@@ -17,10 +17,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.contentColorFor
-import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -55,8 +53,6 @@ fun FullScreenDialog(
     title: String? = null,
     content: @Composable () -> Unit,
 ) {
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-
     FullScreenDialog(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
@@ -74,7 +70,6 @@ fun FullScreenDialog(
                 navigationIcon = {
                     CloseButton(onClose = onDismissRequest)
                 },
-                scrollBehavior = scrollBehavior,
             )
         },
         content = content,
@@ -99,7 +94,6 @@ fun FullScreenDialog(
  *
  * **Used in [FullScreenDialog] composition.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FullScreenDialog(
     onDismissRequest: () -> Unit,
@@ -112,10 +106,7 @@ fun FullScreenDialog(
         onDismissRequest = onDismissRequest,
     ) {
         Surface(modifier = Modifier.fillMaxSize()) {
-            val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-
             Scaffold(
-                modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
                 topBar = { topAppBar() },
             ) { innerPadding ->
                 Column(


### PR DESCRIPTION
# Android | Design System | FullScreenDialog cannot hold SubcomposeLayout

[DCMAW-11706](https://govukverify.atlassian.net/browse/DCMAW-11706)
- Remove scroll from `FullScreenDialog` pattern
- Remove modifier causing `GdsCard` not to displayed in scrollable container

## Evidence of the change

[//]: # (Screenshots / uploaded videos go here)

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [x] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [x] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing


[DCMAW-11706]: https://govukverify.atlassian.net/browse/DCMAW-11706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ