### PR TITLE
fix: add failing test for scrollable content in fullscreendialog pattern

### DIFF
--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.android.ui.patterns.dialog
 
 import android.content.Context
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -46,6 +47,25 @@ class FullScreenDialogTest {
                 title = titleText,
             ) {
                 Text(contentText)
+            }
+        }
+        composeTestRule.onNode(closeButton).assertIsDisplayed()
+        composeTestRule.onNode(title).assertIsDisplayed()
+        composeTestRule.onNode(content).assertIsDisplayed()
+    }
+
+    @Test
+    fun verifyUIScrollableContent() {
+        composeTestRule.setContent {
+            FullScreenDialog(
+                onDismissRequest = { },
+                title = titleText,
+            ) {
+               LazyColumn {
+                   item {
+                       Text(contentText)
+                   }
+               }
             }
         }
         composeTestRule.onNode(closeButton).assertIsDisplayed()

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogTest.kt
@@ -61,11 +61,11 @@ class FullScreenDialogTest {
                 onDismissRequest = { },
                 title = titleText,
             ) {
-               LazyColumn {
-                   item {
-                       Text(contentText)
-                   }
-               }
+                LazyColumn {
+                    item {
+                        Text(contentText)
+                    }
+                }
             }
         }
         composeTestRule.onNode(closeButton).assertIsDisplayed()


### PR DESCRIPTION
# Android | Design System | FullScreenDialog cannot hold SubcomposeLayout

[DCMAW-11706](https://govukverify.atlassian.net/browse/DCMAW-11706)

- Add failing test for scrollable content in `FullScreenDialog` pattern

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change

![Screenshot 2025-03-03 at 10 16 32](https://github.com/user-attachments/assets/c58a62e0-535a-4bb3-ba59-8b211b8093ef)

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing


[DCMAW-11706]: https://govukverify.atlassian.net/browse/DCMAW-11706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ