### PR TITLE
fix: get heading string resource

### DIFF
--- a/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/bulletedlist/BulletedList.kt
+++ b/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/bulletedlist/BulletedList.kt
@@ -79,7 +79,7 @@ private fun BulletedListTitle(
         }
 
         TitleType.Heading -> {
-            titleContentDescription = "${title.text} ${stringResource(R.string.heading)}"
+            titleContentDescription = stringResource(R.string.heading, title.text)
             Typography.headlineSmall
         }
 

--- a/componentsv2/src/main/res/values-cy/strings.xml
+++ b/componentsv2/src/main/res/values-cy/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- BulletedList -->
     <string name="bullet">bwled %s</string>
-    <string name="heading">penawd</string>
+    <string name="heading">%s penawd</string>
     <plurals name="bullet_list_items" translatable="true">
         <item quantity="zero">rhestr bwledi %d eitem</item>
         <item quantity="one">rhestr bwledi %d eitem. bwled %s</item>

--- a/componentsv2/src/main/res/values/strings.xml
+++ b/componentsv2/src/main/res/values/strings.xml
@@ -25,7 +25,7 @@
 
     <!-- BulletedList -->
     <string name="bullet" translatable="true">bullet %s</string>
-    <string name="heading" translatable="true">heading</string>
+    <string name="heading" translatable="true">%s heading</string>
     <plurals name="bullet_list_items" translatable="true">
         <item quantity="one">bulleted list %d item. bullet %s</item>
         <item quantity="other">bulleted list %d items. bullet %s</item>


### PR DESCRIPTION
# Fix get heading string resource


Found in PR review for: [Jira ticket](https://govukverify.atlassian.net/browse/DCMAW-11674?atlOrigin=eyJpIjoiNDhkZjAxNDE0NzE4NDVjNWEyNDJhNjJjNDhmOTE3MTkiLCJwIjoiaiJ9)

- Change strings file to include place holder

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [x] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
