### PR TITLE
fix: Change `contentDescription` for icon on `GdsCard`

### DIFF
--- a/componentsv2/src/androidTest/java/uk/gov/android/ui/componentsv2/GdsCardTest.kt
+++ b/componentsv2/src/androidTest/java/uk/gov/android/ui/componentsv2/GdsCardTest.kt
@@ -88,7 +88,7 @@ class GdsCardTest {
 
             // The same icon description is used for the AnnotatedString used for Secondary Button
             onAllNodesWithContentDescription(
-                resources.getString(R.string.icon_content_desc),
+                resources.getString(R.string.opens_in_external_browser),
             ).assertCountEquals(1)
 
             assertEquals(1, onClick)

--- a/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/GdsCard.kt
+++ b/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/GdsCard.kt
@@ -195,7 +195,7 @@ private fun Buttons(
                             containerColor = MaterialTheme.colorScheme.inverseOnSurface,
                         ),
                         iconImage = ImageVector.vectorResource(R.drawable.ic_external_site),
-                        contentDescription = stringResource(R.string.icon_content_desc),
+                        contentDescription = stringResource(R.string.opens_in_external_browser),
                     ),
                     modifier = Modifier
                         .fillMaxWidth()

--- a/componentsv2/src/main/res/values-cy/strings.xml
+++ b/componentsv2/src/main/res/values-cy/strings.xml
@@ -13,4 +13,5 @@
 
     <!-- Warning -->
     <string name="warning">rhybudd</string>
+    <string name="opens_in_external_browser">Agor mewn porwr gwe</string>
 </resources>

--- a/componentsv2/src/main/res/values/strings.xml
+++ b/componentsv2/src/main/res/values/strings.xml
@@ -33,4 +33,7 @@
 
     <!-- Warning -->
     <string name="warning" translatable="true">warning</string>
+
+    <!-- Custom Icon Content Description -->
+    <string name="opens_in_external_browser">opens in web browser</string>
 </resources>


### PR DESCRIPTION

[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

[//]: # (Be mindful that the PR title also needs to follow conventional commit standards)

# [DCMAW-10470: Update secondary button icon `contentDescription` on `GdsCard` to meet accessibility requirements ](https://govukverify.atlassian.net/browse/DCMAW-10470)

- change `contentDescription` for secondary button icon to "opens in external browser" as the icon is har-coded at the moment, same for its `contentDescription` - this allows meeting accessibility requirements (the change includes teh Welsh translation for the string)

## Evidence of the change

N/a

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [x] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing

Resolves: DCMAW-10470
