### PR TITLE
feat: Add custom back handler for `FullScreenDialogue`

### DIFF
--- a/patterns/src/androidTest/AndroidManifest.xml
+++ b/patterns/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <application>
+        <activity
+            android:name="uk.gov.android.ui.patterns.utils.TestActivity"
+            android:exported="false"
+            android:permission="">
+        </activity>
+    </application>
+</manifest>

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -111,6 +113,26 @@ class FullScreenDialogueTest {
         composeTestRule.onNode(closeButton).performClick()
 
         assertEquals(true, didClose)
+    }
+
+    @Test
+    fun verifyOnBackPress() {
+        var backPress = false
+
+        composeTestRule.setContent {
+            FullScreenDialogue(
+                title = titleText,
+                onDismissRequest = {
+                    backPress = true
+                },
+            ) {
+                Text(contentText)
+            }
+        }
+
+        Espresso.pressBack()
+
+        assertTrue(backPress)
     }
 
     @OptIn(ExperimentalMaterial3Api::class)

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
@@ -11,22 +11,19 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import uk.gov.android.ui.componentsv2.GdsCard
 import uk.gov.android.ui.componentsv2.R
+import uk.gov.android.ui.patterns.utils.FragmentActivityTestCase
 
-class FullScreenDialogueTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
+class FullScreenDialogueTest : FragmentActivityTestCase() {
     private lateinit var closeButton: SemanticsMatcher
     private lateinit var title: SemanticsMatcher
     private lateinit var content: SemanticsMatcher
@@ -134,6 +131,22 @@ class FullScreenDialogueTest {
         Espresso.pressBack()
 
         assertTrue(backPress)
+    }
+
+    @Test
+    fun verifyOnBackPressDefault() {
+        composeTestRule.setContent {
+            FullScreenDialogue(
+                title = titleText,
+                onDismissRequest = {},
+            ) {
+                Text(contentText)
+            }
+        }
+
+        Espresso.pressBack()
+
+        composeTestRule.onNode(title).isNotDisplayed()
     }
 
     @OptIn(ExperimentalMaterial3Api::class)

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -16,6 +17,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -116,15 +118,16 @@ class FullScreenDialogueTest {
     }
 
     @Test
-    fun verifyOnBackPress() {
+    fun verifyOnBackPressSpecificBehaviour() {
         var backPress = false
 
         composeTestRule.setContent {
             FullScreenDialogue(
                 title = titleText,
-                onDismissRequest = {
+                onDismissRequest = {},
+                onBack = {
                     backPress = true
-                },
+                }
             ) {
                 Text(contentText)
             }

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogueTest.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -17,7 +16,6 @@ import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -127,7 +125,7 @@ class FullScreenDialogueTest {
                 onDismissRequest = {},
                 onBack = {
                     backPress = true
-                }
+                },
             ) {
                 Text(contentText)
             }

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/utils/FragmentActivityTestCase.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/utils/FragmentActivityTestCase.kt
@@ -1,0 +1,13 @@
+package uk.gov.android.ui.patterns.utils
+
+import android.content.Context
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Rule
+
+abstract class FragmentActivityTestCase {
+    @get:Rule(order = 1)
+    val composeTestRule = createAndroidComposeRule<TestActivity>()
+
+    protected val context: Context = ApplicationProvider.getApplicationContext()
+}

--- a/patterns/src/androidTest/java/uk/gov/android/ui/patterns/utils/TestActivity.kt
+++ b/patterns/src/androidTest/java/uk/gov/android/ui/patterns/utils/TestActivity.kt
@@ -1,0 +1,5 @@
+package uk.gov.android.ui.patterns.utils
+
+import androidx.fragment.app.FragmentActivity
+
+class TestActivity : FragmentActivity()

--- a/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogue.kt
+++ b/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogue.kt
@@ -1,5 +1,6 @@
 package uk.gov.android.ui.patterns.dialog
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -105,6 +106,7 @@ fun FullScreenDialogue(
                 }
             }
         }
+        BackHandler { onDismissRequest() }
     }
 }
 

--- a/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogue.kt
+++ b/patterns/src/main/java/uk/gov/android/ui/patterns/dialog/FullScreenDialogue.kt
@@ -43,6 +43,7 @@ fun FullScreenDialogue(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     title: String? = null,
+    onBack: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     FullScreenDialogue(
@@ -58,6 +59,7 @@ fun FullScreenDialogue(
                 onCloseClick = onDismissRequest,
             )
         },
+        onBack = onBack,
         content = content,
     )
 }
@@ -77,6 +79,7 @@ fun FullScreenDialogue(
  * @param modifier Modifier to be applied to the layout corresponding to the dialog content
  * @param topAppBar Requires any type of [TopAppBar] to allow customisation.
  *   See [FullScreenDialogTopAppBar] for a pre-configured implementation.
+ * @param onBack Overrides the device back button - if **null**, it will keep the default back button behaviour
  * @param content The content to be displayed inside the dialog.
  *
  * **Used in [FullScreenDialog] composition.
@@ -86,6 +89,7 @@ fun FullScreenDialogue(
     onDismissRequest: () -> Unit,
     topAppBar: @Composable () -> Unit,
     modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     Dialog(
@@ -106,7 +110,9 @@ fun FullScreenDialogue(
                 }
             }
         }
-        BackHandler { onDismissRequest() }
+        if (onBack != null) {
+            BackHandler { onBack() }
+        }
     }
 }
 


### PR DESCRIPTION
[Tutorial for writing good descriptions]: https://cbea.ms/git-commit/

[//]: # 

#[ Add custom back handler for `FullScreenDialogue`](https://govukverify.atlassian.net/browse/DCMAW-11964)

- When using the `FullScreenDialogue` in the `LocalAuthImplementation` - we require custom back behaviour. Based on the FullScreenDialogue implementation it looks like the dismiss is always required which would technically have the same behaviour as pressing the device back button. We have talked about this in MP and overall the back button behaviour would always align with the dismiss - however, please do raise any potential issues if there are cases/ situations I might have missed/ not account for - **This should not be a breaking change as it's not changing the API, rather than assigning the `onDismissRequest` to the `BackHandler`**

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change
No evidence to show - check code

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.

### Before the CODEOWNERS review the pull request

- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [x] Integration Tests.
  * [x] Instrumentation / Emulator Tests.
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
