### PR TITLE
fix: adjust talkback behaviour for inline icons

### DIFF
--- a/componentsv2/src/androidTest/java/uk/gov/android/ui/componentsv2/text/GdsAnnotatedStringTest.kt
+++ b/componentsv2/src/androidTest/java/uk/gov/android/ui/componentsv2/text/GdsAnnotatedStringTest.kt
@@ -4,11 +4,15 @@ import android.content.Context
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import uk.gov.android.ui.componentsv2.R
@@ -44,6 +48,39 @@ class GdsAnnotatedStringTest {
             onNodeWithContentDescription(
                 resources.getString(R.string.icon_content_desc),
             ).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun testStringIconContentDescription() {
+        composeTestRule.setContent {
+            GdsAnnotatedString(
+                text = stringResource(parameters.text),
+                fontWeight = parameters.fontWeight,
+                icon = ImageVector.vectorResource(parameters.icon),
+                iconContentDescription = stringResource(parameters.iconContentDescription),
+                iconId = stringResource(parameters.iconId),
+                iconColor = parameters.iconColor,
+                iconBackgroundColor = parameters.iconBackgroundColor,
+                isIconTrailing = parameters.isIconTrailing,
+            )
+        }
+        composeTestRule.apply {
+            onNodeWithText(
+                resources.getString(R.string.annotated_string),
+                substring = true,
+            )
+                .assertTextEquals("Annotated string[Icon Description]")
+
+            val icon = onNodeWithContentDescription(
+                resources.getString(R.string.icon_content_desc),
+            ).fetchSemanticsNode()
+
+            assertTrue(
+                SemanticsMatcher
+                    .expectValue(SemanticsProperties.InvisibleToUser, Unit)
+                    .matches(icon),
+            )
         }
     }
 

--- a/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/text/GdsAnnotatedString.kt
+++ b/componentsv2/src/main/java/uk/gov/android/ui/componentsv2/text/GdsAnnotatedString.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
@@ -44,9 +46,9 @@ fun GdsAnnotatedString(
     val annotatedString: AnnotatedString = buildAnnotatedString {
         if (isIconTrailing) {
             append(AnnotatedString(text))
-            appendInlineContent(iconId, "[icon]")
+            appendInlineContent(iconId, "[$iconContentDescription]")
         } else {
-            appendInlineContent(iconId, "[icon]")
+            appendInlineContent(iconId, "[$iconContentDescription]")
             append(AnnotatedString(text))
         }
     }
@@ -66,7 +68,8 @@ fun GdsAnnotatedString(
                     color = iconColor,
                     backgroundColor = iconBackgroundColor,
                     modifier = Modifier
-                        .padding(start = xsmallPadding),
+                        .padding(start = xsmallPadding)
+                        .semantics { invisibleToUser() },
                 )
             },
         ),


### PR DESCRIPTION
# DCMAW-11595 | Adjust Talkback Behaviour

"icon" is no longer read out as part of icons within `GdsAnnotatedString`.
This is required to create the correct behaviour on [DCMAW-11595: Android | Handback | Create MAM Handback Screen](https://govukverify.atlassian.net/browse/DCMAW-11595).
<img width="699" alt="image" src="https://github.com/user-attachments/assets/ab6d958b-7a22-4c17-913c-f6d37642149a" />

## Evidence of the change

See unit test: `GdsAnnotatedStringTest.testStringIconContentDescription`.

## Checklist

### Before creating the pull request

- [x] Commit messages that conform to conventional commit messages.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [x] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] ~~Complete all Acceptance Criteria within Jira ticket~~ - separate PR is required for the functional change
- [x] Self-review code.
- [x] Successfully run changes on a testing device.
- [x] Complete automated Testing:
  * [x] Unit Tests.
  * [ ] ~~Integration Tests.~~
  * [ ] ~~Instrumentation / Emulator Tests.~~
- [x] Review [Accessibility considerations].
- [x] Handle PR comments.

### Before merging the pull request

- [x] [Sonar cloud report] passes inspections for your PR.
- [x] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
