### PR TITLE
fix: add default text value to loading screen pattern

### DIFF
--- a/patterns/src/main/java/uk/gov/android/ui/patterns/loadingscreen/LoadingScreen.kt
+++ b/patterns/src/main/java/uk/gov/android/ui/patterns/loadingscreen/LoadingScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import uk.gov.android.ui.patterns.R
 import uk.gov.android.ui.theme.largePadding
@@ -52,7 +52,7 @@ fun LoadingScreen(
 }
 
 @OptIn(UnstableDesignSystemAPI::class)
-@Preview
+@PreviewLightDark
 @Composable
 private fun PreviewDefaultLoadingScreen(
     @PreviewParameter(LoadingScreenContentProvider::class)
@@ -64,7 +64,7 @@ private fun PreviewDefaultLoadingScreen(
 }
 
 @OptIn(UnstableDesignSystemAPI::class)
-@Preview
+@PreviewLightDark
 @Composable
 private fun PreviewDefaultLoadingScreenNoContent() {
     GdsTheme {

--- a/patterns/src/main/java/uk/gov/android/ui/patterns/loadingscreen/LoadingScreen.kt
+++ b/patterns/src/main/java/uk/gov/android/ui/patterns/loadingscreen/LoadingScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import uk.gov.android.ui.patterns.R
 import uk.gov.android.ui.theme.largePadding
 import uk.gov.android.ui.theme.m3.GdsTheme
 import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
@@ -30,8 +32,8 @@ import uk.gov.android.ui.theme.util.UnstableDesignSystemAPI
 @UnstableDesignSystemAPI
 @Composable
 fun LoadingScreen(
-    text: String,
     modifier: Modifier = Modifier,
+    text: String = stringResource(R.string.loading),
 ) {
     Column(
         modifier = modifier.fillMaxSize(),
@@ -58,5 +60,14 @@ private fun PreviewDefaultLoadingScreen(
 ) {
     GdsTheme {
         LoadingScreen(text = content)
+    }
+}
+
+@OptIn(UnstableDesignSystemAPI::class)
+@Preview
+@Composable
+private fun PreviewDefaultLoadingScreenNoContent() {
+    GdsTheme {
+        LoadingScreen()
     }
 }

--- a/patterns/src/main/res/values-cy/strings.xml
+++ b/patterns/src/main/res/values-cy/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="error_icon_description">Gwall</string>
     <string name="warning_icon_description">Rhybudd</string>
+    <string name="loading">Llwytho</string>
 </resources>

--- a/patterns/src/main/res/values/strings.xml
+++ b/patterns/src/main/res/values/strings.xml
@@ -3,4 +3,5 @@
     <string name="preview__GdsVectorImage__description" translatable="false">Image description</string>
     <string name="error_icon_description">Error</string>
     <string name="warning_icon_description">Warning</string>
+    <string name="loading">Loading</string>
 </resources>


### PR DESCRIPTION
Changes:
- note: this is for the `patterns/loadingscreen` composable, not for `pages/loadingscreen` composable
- add default value to the loading screen pattern text, which is "Loading" - Welsh translation also added

## Evidence of the change

## Checklist

### Before creating the pull request

- [ ] Commit messages that conform to conventional commit messages.
- [ ] Ran the app locally ensuring it builds.
- [ ] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [ ] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
