### PR TITLE
fix: move process camera provider unbind into main thread

### DIFF
--- a/componentsv2/componentsv2-camera/src/main/java/uk/gov/android/ui/componentsv2/camera/CameraContent.kt
+++ b/componentsv2/componentsv2-camera/src/main/java/uk/gov/android/ui/componentsv2/camera/CameraContent.kt
@@ -109,9 +109,8 @@ fun CameraContent(
         val provider = ProcessCameraProvider.getInstance(context).get()
 
         coroutineScope.launch {
-            provider.unbindAll()
-
             withContext(mainDispatcher) {
+                provider.unbindAll()
                 cameraUpdater.update(
                     provider.bindToLifecycle(
                         lifecycleOwner,


### PR DESCRIPTION
## Fix race condition when running instrumentation tests
https://github.com/govuk-one-login/mobile-credential-sharing-android/pull/393

- move `provider.unbindAll()` into main thread

[//]: # (e.g. "- Create 'androidLibrary' Gradle module.")

## Evidence of the change

Before fix:

<img width="1866" height="740" alt="Screenshot 2026-06-16 at 17 28 01" src="https://github.com/user-attachments/assets/648c6f9c-ae27-45d8-8132-5a22e4b4451b" />

----
After fix (using mavenLocal)

<img width="1440" height="670" alt="Screenshot 2026-06-16 at 17 30 52" src="https://github.com/user-attachments/assets/1d4df8f2-028e-4419-b3d7-da4e3ef088d4" />



## Checklist

### Before creating the pull request

- [x] Messages conform to conventional commits.
- [x] Ran the app locally ensuring it builds.
- [x] Tests pass locally.
- [ ] Pull request has a clear title with a short description about the feature or update.
- [x] Created a `draft` pull request if it's not ready for review.

### Before the CODEOWNERS review the pull request

- [ ] Complete all Acceptance Criteria within Jira ticket.
- [ ] Self-review code.
- [ ] Successfully run changes on a testing device.
- [ ] Complete automated Testing:
  * [ ] Unit Tests.
  * [ ] Integration Tests.
  * [ ] Instrumentation / Emulator Tests.
- [ ] Review [Accessibility considerations].
- [ ] Handle PR comments.

### Before merging the pull request

- [ ] [Sonar cloud report] passes inspections for your PR.
- [ ] Resolve all comments.

[Sonar cloud report]: https://sonarcloud.io/project/overview?id=di-mobile-android-ui
[Accessibility considerations]: https://developer.android.com/guide/topics/ui/accessibility/testing
